### PR TITLE
Adapt package.json for everyone

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "undum": "git://github.com/sequitur/undum.git#commonjs",
-    "raconteur": "git://github.com/sequitur/raconteur.git#stable",
+    "undum-commonjs": "https://github.com/sequitur/undum.git#commonjs",
+    "raconteur": "https://github.com/sequitur/raconteur.git#stable",
     "jquery": "^2.1.3",
     "markdown-it": "^4.1.0"
   },


### PR DESCRIPTION
npm can't install links from github if there are of the form git:// (maybe if you are contributor of the project but not otherwise).
Furthermore, undum state that its package name is undum-commonjs in their package.json so without this in our package.json, npm can't find anything
